### PR TITLE
Histignore

### DIFF
--- a/link/.histignore
+++ b/link/.histignore
@@ -1,0 +1,42 @@
+################################################################################
+# This file is used to populate the HISTIGNORE environment variable. Each line
+# is a separate regex. If a command matches one of the regexes then it will be
+# ignored. To ignore a command, a regex must match the entire command from start
+# to end.
+# A '&' character matches the previous history line and can be escaped using a
+# backslash character.
+#
+# This file is sourced using the shignore command in the universal aliases file.
+# Empty lines and ones starting with a '#' will be treated like a comment and
+# ignored.
+################################################################################
+exit
+logout
+
+sudo &
+
+[fb]g
+
+rs
+
+ls?([lah])
+ls -[la]
+
+# repository functions
+svn[bcr]
+up
+st
+ci?( ?(-m )"*")
+br
+
+# file sourcing
+@(p|m|s|u)aliases
+s?(p|m|s|u)alias
+src
+sdirs
+spath
+svars
+shignore
+
+@(cd|..|?(h)top|history?(|*))?( *)
+pa_@(cluster|mac)

--- a/source/aliases_universal.bash
+++ b/source/aliases_universal.bash
@@ -1789,7 +1789,16 @@ export HISTSIZE=9999999999
 
 # ignore commands that start with a ' ' and duplicate commands
 export HISTCONTROL=ignoreboth
-export HISTIGNORE='sudo &:[fb]g:rs:exit:logout:ls?([la]):ls -[la]:svn[bcr]:up:st:ci?( ?(-m )"*"):cluster[0-9]:@(p|m|s|u)aliases:s?(p|m|s|u)alias:src:sdirs:spath:svars:@(cd|..|?(h)top|history?(|*))?( *):pa_@(cluster|mac)'
+export HISTIGNORE_FILE="$HOME/.histignore"
+# ehignore: edit histignore file
+ehignore() { edit "$HISTIGNORE_FILE"; } # [BH]
+# shignore: source histignore file
+shignore() { # [BH]
+	export HISTIGNORE="`egrep -v '^\s*#' "$HISTIGNORE_FILE" \
+		| grep -v '^$' \
+		| tr '\n' ':'`"
+}
+shignore
 
 # store the time that each command was entered
 export HISTTIMEFORMAT='%F %T '

--- a/source/aliases_universal.bash
+++ b/source/aliases_universal.bash
@@ -1796,7 +1796,8 @@ ehignore() { edit "$HISTIGNORE_FILE"; } # [BH]
 shignore() { # [BH]
 	export HISTIGNORE="`egrep -v '^\s*#' "$HISTIGNORE_FILE" \
 		| grep -v '^$' \
-		| tr '\n' ':'`"
+		| tr '\n' ':' \
+		| sed 's/:*$//'`"
 }
 shignore
 


### PR DESCRIPTION
made HISTIGNORE setup more legible by pulling it out into a separate file and adding a function to parse it and ignore commented / empty lines
